### PR TITLE
feat: add ctx7 CLI to mise config and install context7 skills

### DIFF
--- a/.agents/skills/context7-cli
+++ b/.agents/skills/context7-cli
@@ -1,0 +1,1 @@
+../../.claude/skills/context7-cli

--- a/.agents/skills/find-docs
+++ b/.agents/skills/find-docs
@@ -1,0 +1,1 @@
+../../.claude/skills/find-docs

--- a/.chezmoisource/dot_config/mise/config.toml.tmpl
+++ b/.chezmoisource/dot_config/mise/config.toml.tmpl
@@ -118,6 +118,7 @@ biome = "latest"
 "pipx:mcp2cli" = "latest"
 "npm:@googleworkspace/cli" = "latest"
 "npm:@claude-flow/cli" = "latest"
+"npm:ctx7" = "latest"
 
 # ── Migrated from bun/uv globals ──
 "npm:@augmentcode/auggie" = "latest"

--- a/.claude/agent-memory/researcher/MEMORY.md
+++ b/.claude/agent-memory/researcher/MEMORY.md
@@ -3,4 +3,5 @@
 ## References
 
 - [LSP "0 servers" root cause](finding_lsp_plugins_disabled_root_cause.md) — Plugins installed but disabled is #1 cause of LSP setup failures; check `claude plugin list` before assuming flag issue
+- [Context7 platform for live docs](reference_context7_platform.md) — MCP + CLI for pulling current library docs into prompts; resolves hallucinated APIs from training data cutoff
 

--- a/.claude/agent-memory/researcher/reference_context7_platform.md
+++ b/.claude/agent-memory/researcher/reference_context7_platform.md
@@ -1,0 +1,74 @@
+---
+name: Context7 platform for live docs
+description: MCP server + CLI tool that pulls current library docs into LLM context, resolves hallucinated APIs from training data cutoff
+type: reference
+---
+
+## URL References
+
+- **Main repo:** https://github.com/upstash/context7 (50k+ stars, MIT)
+- **CLI SKILL.md:** https://github.com/upstash/context7/blob/master/skills/context7-cli/SKILL.md
+- **Official site:** https://context7.com
+- **Dashboard (API keys):** https://context7.com/dashboard
+- **CLI docs:** https://context7.com/docs/clients/cli
+- **MCP manual install:** https://context7.com/docs/resources/all-clients
+
+## Quick Facts
+
+- **Problem solved:** LLMs hallucinate APIs and use outdated docs from training data cutoff
+- **Solution:** Fetches live, version-specific docs from source → injects into prompt
+- **Modes:** CLI+Skills or pure MCP integration
+- **Install:** `npx ctx7 setup` (interactive, OAuth auth)
+- **Language:** TypeScript
+- **License:** MIT
+- **Auth:** OAuth, API key, or `CONTEXT7_API_KEY` env var
+- **Rate limits:** Higher limits with free API key from context7.com/dashboard
+
+## CLI Commands (SKILL.md Reference)
+
+### Library Resolution
+```bash
+ctx7 library <name> <query>        # Finds library ID (e.g., /facebook/react)
+```
+
+### Documentation Fetching
+```bash
+ctx7 docs <libraryId> <query>      # Gets version-specific docs for library
+```
+
+### Skill Management
+```bash
+ctx7 skills install /owner/repo    # Install from GitHub repo
+ctx7 skills search <keywords>      # Search registry
+ctx7 skills suggest                # Auto-suggest based on project deps
+ctx7 skills list                   # List installed skills
+ctx7 skills remove <name>          # Uninstall
+ctx7 skills generate               # AI-generated custom skill (requires login)
+```
+
+### Setup & Auth
+```bash
+ctx7 setup                         # Interactive MCP/skill setup
+ctx7 login                         # OAuth
+ctx7 login --no-browser            # Print URL instead of opening browser
+ctx7 logout                        # Clear tokens
+ctx7 whoami                        # Check login status
+```
+
+## MCP Tools (when using MCP mode)
+
+- **resolve-library-id:** Takes library name + query, returns Context7 ID
+- **query-docs:** Takes library ID + query, returns documentation
+
+## Key Concepts
+
+- **Library ID format:** `/owner/repo` or `/namespace/library` (slash prefix required)
+- **Version targeting:** Mention version in prompt (e.g., "Next.js 14") → auto-matches
+- **Rule-based triggering:** Can set rule in CLAUDE.md/Cursor Rules/etc. to auto-invoke for library questions
+
+## For MDE Integration
+
+- Add `ctx7` to mise config (prefer registry backend)
+- Optional: `uv run mde-py` could expose ctx7 as a subcommand
+- Consider both CLI (for scripting) and MCP (for Claude Code native integration)
+- Use --api-key flag for CI/CD flows to skip OAuth browser prompt

--- a/.claude/skills/context7-cli/SKILL.md
+++ b/.claude/skills/context7-cli/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: context7-cli
+description: Use the ctx7 CLI to fetch library documentation, manage AI coding skills, and configure Context7 MCP. Activate when the user mentions "ctx7" or "context7", needs current docs for any library, wants to install/search/generate skills, or needs to set up Context7 for their AI coding agent.
+---
+
+# ctx7 CLI
+
+The Context7 CLI does three things: fetches up-to-date library documentation, manages AI coding skills, and sets up Context7 MCP for your editor.
+
+Make sure the CLI is up to date before running commands:
+
+```bash
+npm install -g ctx7@latest
+```
+
+Or run directly without installing:
+
+```bash
+npx ctx7@latest <command>
+```
+
+## What this skill covers
+
+- **[Documentation](references/docs.md)** — Fetch current docs for any library. Use when writing code, verifying API signatures, or when training data may be outdated.
+- **[Skills management](references/skills.md)** — Install, search, suggest, list, remove, and generate AI coding skills.
+- **[Setup](references/setup.md)** — Configure Context7 MCP for Claude Code / Cursor / OpenCode.
+
+## Quick Reference
+
+```bash
+# Documentation
+ctx7 library <name> <query>           # Step 1: resolve library ID
+ctx7 docs <libraryId> <query>         # Step 2: fetch docs
+
+# Skills
+ctx7 skills install /owner/repo       # Install from a repo (interactive)
+ctx7 skills install /owner/repo name  # Install a specific skill
+ctx7 skills search <keywords>         # Search the registry
+ctx7 skills suggest                   # Auto-suggest based on project deps
+ctx7 skills list                      # List installed skills
+ctx7 skills remove <name>             # Uninstall a skill
+ctx7 skills generate                  # Generate a custom skill with AI (requires login)
+
+# Setup
+ctx7 setup                            # Configure Context7 MCP (interactive)
+ctx7 login                            # Log in for higher rate limits + skill generation
+ctx7 whoami                           # Check current login status
+```
+
+## Authentication
+
+```bash
+ctx7 login               # Opens browser for OAuth
+ctx7 login --no-browser  # Prints URL instead of opening browser
+ctx7 logout              # Clear stored tokens
+ctx7 whoami              # Show current login status (name + email)
+```
+
+Most commands work without login. Exceptions: `skills generate` always requires it; `ctx7 setup` requires it unless `--api-key` or `--oauth` is passed. Login also unlocks higher rate limits on docs commands.
+
+Set an API key via environment variable to skip interactive login entirely:
+
+```bash
+export CONTEXT7_API_KEY=your_key
+```
+
+## Common Mistakes
+
+- Library IDs require a `/` prefix — `/facebook/react` not `facebook/react`
+- Always run `ctx7 library` first — `ctx7 docs react "hooks"` will fail without a valid ID
+- Repository format for skills is `/owner/repo` — e.g., `ctx7 skills install /anthropics/skills`
+- `skills generate` requires login — run `ctx7 login` first

--- a/.claude/skills/context7-cli/references/docs.md
+++ b/.claude/skills/context7-cli/references/docs.md
@@ -1,0 +1,113 @@
+# Documentation Commands
+
+Retrieves and queries up-to-date documentation and code examples from Context7 for any programming library or framework. Two-step workflow: resolve the library name to get its ID, then query docs using that ID.
+
+If the user already provided a library ID in `/org/project` or `/org/project/version` format, pass it directly to `ctx7 docs`.
+
+## Step 1: Resolve a Library
+
+Resolves a package/product name to a Context7-compatible library ID and returns matching libraries.
+
+```bash
+ctx7 library react "How to clean up useEffect with async operations"
+ctx7 library nextjs "How to set up app router with middleware"
+ctx7 library prisma "How to define one-to-many relations with cascade delete"
+```
+
+Always pass a `query` argument — it is required and directly affects result ranking. Use the user's intent to form the query, which helps disambiguate when multiple libraries share a similar name. Do not include any sensitive or confidential information such as API keys, passwords, credentials, personal data, or proprietary code in your query.
+
+### Result fields
+
+Each result includes:
+
+- **Library ID** — Context7-compatible identifier (format: `/org/project`)
+- **Name** — Library or package name
+- **Description** — Short summary
+- **Code Snippets** — Number of available code examples
+- **Source Reputation** — Authority indicator (High, Medium, Low, or Unknown)
+- **Benchmark Score** — Quality indicator (100 is the highest score)
+- **Versions** — List of versions if available. Use one of those versions if the user provides a version in their query. The format is `/org/project/version`.
+
+### Selection process
+
+1. Analyze the query to understand what library/package the user is looking for
+2. Select the most relevant match based on:
+   - Name similarity to the query (exact matches prioritized)
+   - Description relevance to the query's intent
+   - Documentation coverage (prioritize libraries with higher Code Snippet counts)
+   - Source reputation (consider libraries with High or Medium reputation more authoritative)
+   - Benchmark score (higher is better, 100 is the maximum)
+3. If multiple good matches exist, acknowledge this but proceed with the most relevant one
+4. If no good matches exist, clearly state this and suggest query refinements
+5. For ambiguous queries, request clarification before proceeding with a best-guess match
+
+IMPORTANT: Do not call `ctx7 library` more than 3 times per question. If you cannot find what you need after 3 calls, use the best result you have.
+
+### Version-specific IDs
+
+If the user mentions a specific version, use a version-specific library ID:
+
+```bash
+# General (latest indexed)
+ctx7 docs /vercel/next.js "How to set up app router"
+
+# Version-specific
+ctx7 docs /vercel/next.js/v14.3.0-canary.87 "How to set up app router"
+```
+
+The available versions are listed in the `ctx7 library` output. Use the closest match to what the user specified.
+
+```bash
+# Output as JSON for scripting
+ctx7 library react "How to use hooks for state management" --json | jq '.[0].id'
+```
+
+## Step 2: Query Documentation
+
+Retrieves up-to-date documentation and code examples for the resolved library.
+
+You must call `ctx7 library` first to obtain the exact Context7-compatible library ID required to use this command, UNLESS the user explicitly provides a library ID in the format `/org/project` or `/org/project/version`.
+
+```bash
+ctx7 docs /facebook/react "How to clean up useEffect with async operations"
+ctx7 docs /vercel/next.js "How to add authentication middleware to app router"
+ctx7 docs /prisma/prisma "How to define one-to-many relations with cascade delete"
+```
+
+IMPORTANT: Do not call `ctx7 docs` more than 3 times per question. If you cannot find what you need after 3 calls, use the best information you have.
+
+### Writing good queries
+
+The query directly affects the quality of results. Be specific and include relevant details. Do not include any sensitive or confidential information such as API keys, passwords, credentials, personal data, or proprietary code in your query.
+
+| Quality | Example |
+|---------|---------|
+| Good | `"How to set up authentication with JWT in Express.js"` |
+| Good | `"React useEffect cleanup function with async operations"` |
+| Bad | `"auth"` |
+| Bad | `"hooks"` |
+
+Use the user's full question as the query when possible — vague one-word queries return generic results.
+
+The output contains two types of content: **code snippets** (titled, with language-tagged blocks) and **info snippets** (prose explanations with breadcrumb context).
+
+```bash
+# Output as structured JSON
+ctx7 docs /facebook/react "How to use hooks for state management" --json
+
+# Pipe to other tools — output is clean when not in a TTY (no spinners or colors)
+ctx7 docs /facebook/react "How to use hooks for state management" | head -50
+ctx7 docs /vercel/next.js "How to add middleware for route protection" | grep -A5 "middleware"
+```
+
+## Authentication
+
+Works without authentication. For higher rate limits:
+
+```bash
+# Option A: environment variable
+export CONTEXT7_API_KEY=your_key
+
+# Option B: OAuth login
+ctx7 login
+```

--- a/.claude/skills/context7-cli/references/setup.md
+++ b/.claude/skills/context7-cli/references/setup.md
@@ -1,0 +1,43 @@
+# Setup
+
+## ctx7 setup
+
+One-time command to configure Context7 for your AI coding agent. Prompts for mode on first run:
+- **MCP server** — registers the Context7 MCP server so the agent can call tools natively
+- **CLI + Skills** — installs a `find-docs` skill that guides the agent to use `ctx7` CLI commands (no MCP required)
+
+```bash
+ctx7 setup                     # Interactive — prompts for mode, then agent/install target
+ctx7 setup --mcp               # Skip prompt, use MCP server mode
+ctx7 setup --cli               # Skip prompt, use CLI + Skills mode
+
+# MCP mode — target a specific agent
+ctx7 setup --claude            # Claude Code only
+ctx7 setup --cursor            # Cursor only
+ctx7 setup --opencode          # OpenCode only
+
+# CLI + Skills mode — target a specific install location
+ctx7 setup --cli --claude      # Claude Code (~/.claude/skills)
+ctx7 setup --cli --cursor      # Cursor (~/.cursor/skills)
+ctx7 setup --cli --universal   # Universal (~/.agents/skills)
+ctx7 setup --cli --antigravity # Antigravity (~/.config/agent/skills)
+
+ctx7 setup --project           # Configure current project instead of globally
+ctx7 setup --yes               # Skip confirmation prompts
+```
+
+**Authentication options:**
+```bash
+ctx7 setup --api-key YOUR_KEY  # Use an existing API key (both MCP and CLI + Skills mode)
+ctx7 setup --oauth             # OAuth endpoint — MCP mode only (IDE handles the auth flow)
+```
+
+Without `--api-key` or `--oauth`, setup opens a browser for OAuth login. MCP mode additionally generates a new API key after login. `--oauth` is MCP-only.
+
+**What gets written — MCP mode:**
+- MCP server entry in the agent's config file (`.mcp.json` for Claude, `.cursor/mcp.json` for Cursor, `.opencode.json` for OpenCode)
+- A Context7 rule file instructing the agent to use Context7 for library docs
+- A `context7-mcp` skill in the agent's skills directory
+
+**What gets written — CLI + Skills mode:**
+- A `find-docs` skill in the chosen agent's skills directory, guiding the agent to use `ctx7 library` and `ctx7 docs` commands

--- a/.claude/skills/context7-cli/references/skills.md
+++ b/.claude/skills/context7-cli/references/skills.md
@@ -1,0 +1,118 @@
+# Skills Commands
+
+Manage AI coding skills from the Context7 registry. Skills are Markdown files that teach AI coding agents best practices, patterns, and workflows for specific libraries or tasks.
+
+## Install
+
+Install skills from any GitHub repository. Repository format is always `/owner/repo`.
+
+```bash
+ctx7 skills install /anthropics/skills           # Interactive — pick from a list
+ctx7 skills install /anthropics/skills pdf        # Install a specific skill by name
+ctx7 skills install /anthropics/skills --all      # Install everything without prompting
+```
+
+Target a specific IDE with a flag:
+```bash
+ctx7 skills install /anthropics/skills pdf --claude     # Claude Code only
+ctx7 skills install /anthropics/skills pdf --cursor     # Cursor only
+ctx7 skills install /anthropics/skills pdf --universal  # Universal (.agents/skills/)
+ctx7 skills install /anthropics/skills --all --global   # All skills, global install
+```
+
+Alias: `ctx7 si /anthropics/skills pdf`
+
+## Search
+
+Find skills across the entire registry by keyword. Shows an interactive list with install counts and trust scores. Select to install.
+
+```bash
+ctx7 skills search pdf
+ctx7 skills search typescript testing
+ctx7 skills search react nextjs
+```
+
+Alias: `ctx7 ss pdf`
+
+## Suggest
+
+Auto-detects your project dependencies and recommends relevant skills from the registry.
+
+```bash
+ctx7 skills suggest           # Scan current project, install to project
+ctx7 skills suggest --global  # Install suggestions globally
+ctx7 skills suggest --claude  # Target Claude Code only
+```
+
+Reads `package.json`, `requirements.txt`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Gemfile`. Falls back to suggesting `ctx7 skills search` if no dependencies are detected.
+
+Alias: `ctx7 ssg`
+
+## Generate (AI-powered)
+
+Generate a custom skill tailored to your stack using AI. **Requires login.**
+
+```bash
+ctx7 skills generate
+ctx7 skills generate --claude   # Install directly to Claude Code
+ctx7 skills generate --global   # Install to global skills
+```
+
+Interactive flow:
+1. Describe the expertise you want (e.g., "OAuth authentication with NextAuth.js")
+2. Select relevant libraries from search results
+3. Answer 3 clarifying questions to focus the skill
+4. Review the generated skill, request changes if needed
+5. Choose where to install it
+
+**Limits:** Free accounts get 6 generations/week, Pro accounts get 10.
+
+Aliases: `ctx7 skills gen`, `ctx7 skills g`
+
+## List
+
+Show all installed skills for the current project or globally.
+
+```bash
+ctx7 skills list                  # Current project (all detected IDEs)
+ctx7 skills list --claude         # Claude Code only
+ctx7 skills list --global         # Global skills
+ctx7 skills list --global --claude # Global Claude Code skills
+```
+
+## Remove
+
+Uninstall a skill by name.
+
+```bash
+ctx7 skills remove pdf
+ctx7 skills remove pdf --claude   # From Claude Code only
+ctx7 skills remove pdf --global   # From global skills
+```
+
+Aliases: `ctx7 skills rm`, `ctx7 skills delete`
+
+## Info
+
+Browse all skills in a repository without installing — useful for previewing what's available.
+
+```bash
+ctx7 skills info /anthropics/skills
+```
+
+Output shows each skill name, description, and URL, plus quick install commands.
+
+## IDE Flags
+
+All skills commands accept these flags to target a specific AI coding assistant:
+
+| Flag | Directory | Used by |
+|------|-----------|---------|
+| `--universal` | `.agents/skills/` | Amp, Codex, Gemini CLI, OpenCode, GitHub Copilot |
+| `--claude` | `.claude/skills/` | Claude Code |
+| `--cursor` | `.cursor/skills/` | Cursor |
+| `--antigravity` | `.agent/skills/` | Antigravity |
+
+Without a flag, the CLI prompts you to select one or more targets interactively.
+
+Add `--global` to any flag to install in your home directory instead of the current project.

--- a/.claude/skills/find-docs/SKILL.md
+++ b/.claude/skills/find-docs/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: find-docs
+description: >-
+  Retrieves authoritative, up-to-date technical documentation, API references,
+  configuration details, and code examples for any developer technology.
+
+  Use this skill whenever answering technical questions or writing code that
+  interacts with external technologies. This includes libraries, frameworks,
+  programming languages, SDKs, APIs, CLI tools, cloud services, infrastructure
+  tools, and developer platforms.
+
+  Common scenarios:
+  - looking up API endpoints, classes, functions, or method parameters
+  - checking configuration options or CLI commands
+  - answering "how do I" technical questions
+  - generating code that uses a specific library or service
+  - debugging issues related to frameworks, SDKs, or APIs
+  - retrieving setup instructions, examples, or migration guides
+  - verifying version-specific behavior or breaking changes
+
+  Prefer this skill whenever documentation accuracy matters or when model
+  knowledge may be outdated.
+---
+
+# Documentation Lookup
+
+Retrieve current documentation and code examples for any library using the Context7 CLI.
+
+Make sure the CLI is up to date before running commands:
+
+```bash
+npm install -g ctx7@latest
+```
+
+Or run directly without installing:
+
+```bash
+npx ctx7@latest <command>
+```
+
+## Workflow
+
+Two-step process: resolve the library name to an ID, then query docs with that ID.
+
+```bash
+# Step 1: Resolve library ID
+ctx7 library <name> <query>
+
+# Step 2: Query documentation
+ctx7 docs <libraryId> <query>
+```
+
+You MUST call `ctx7 library` first to obtain a valid library ID UNLESS the user explicitly provides a library ID in the format `/org/project` or `/org/project/version`.
+
+IMPORTANT: Do not run these commands more than 3 times per question. If you cannot find what you need after 3 attempts, use the best result you have.
+
+## Step 1: Resolve a Library
+
+Resolves a package/product name to a Context7-compatible library ID and returns matching libraries.
+
+```bash
+ctx7 library react "How to clean up useEffect with async operations"
+ctx7 library nextjs "How to set up app router with middleware"
+ctx7 library prisma "How to define one-to-many relations with cascade delete"
+```
+
+Always pass a `query` argument — it is required and directly affects result ranking. Use the user's intent to form the query, which helps disambiguate when multiple libraries share a similar name. Do not include any sensitive or confidential information such as API keys, passwords, credentials, personal data, or proprietary code in your query.
+
+### Result fields
+
+Each result includes:
+
+- **Library ID** — Context7-compatible identifier (format: `/org/project`)
+- **Name** — Library or package name
+- **Description** — Short summary
+- **Code Snippets** — Number of available code examples
+- **Source Reputation** — Authority indicator (High, Medium, Low, or Unknown)
+- **Benchmark Score** — Quality indicator (100 is the highest score)
+- **Versions** — List of versions if available. Use one of those versions if the user provides a version in their query. The format is `/org/project/version`.
+
+### Selection process
+
+1. Analyze the query to understand what library/package the user is looking for
+2. Select the most relevant match based on:
+   - Name similarity to the query (exact matches prioritized)
+   - Description relevance to the query's intent
+   - Documentation coverage (prioritize libraries with higher Code Snippet counts)
+   - Source reputation (consider libraries with High or Medium reputation more authoritative)
+   - Benchmark score (higher is better, 100 is the maximum)
+3. If multiple good matches exist, acknowledge this but proceed with the most relevant one
+4. If no good matches exist, clearly state this and suggest query refinements
+5. For ambiguous queries, request clarification before proceeding with a best-guess match
+
+### Version-specific IDs
+
+If the user mentions a specific version, use a version-specific library ID:
+
+```bash
+# General (latest indexed)
+ctx7 docs /vercel/next.js "How to set up app router"
+
+# Version-specific
+ctx7 docs /vercel/next.js/v14.3.0-canary.87 "How to set up app router"
+```
+
+The available versions are listed in the `ctx7 library` output. Use the closest match to what the user specified.
+
+## Step 2: Query Documentation
+
+Retrieves up-to-date documentation and code examples for the resolved library.
+
+```bash
+ctx7 docs /facebook/react "How to clean up useEffect with async operations"
+ctx7 docs /vercel/next.js "How to add authentication middleware to app router"
+ctx7 docs /prisma/prisma "How to define one-to-many relations with cascade delete"
+```
+
+### Writing good queries
+
+The query directly affects the quality of results. Be specific and include relevant details. Do not include any sensitive or confidential information such as API keys, passwords, credentials, personal data, or proprietary code in your query.
+
+| Quality | Example |
+|---------|---------|
+| Good | `"How to set up authentication with JWT in Express.js"` |
+| Good | `"React useEffect cleanup function with async operations"` |
+| Bad | `"auth"` |
+| Bad | `"hooks"` |
+
+Use the user's full question as the query when possible, vague one-word queries return generic results.
+
+The output contains two types of content: **code snippets** (titled, with language-tagged blocks) and **info snippets** (prose explanations with breadcrumb context).
+
+## Authentication
+
+Works without authentication. For higher rate limits:
+
+```bash
+# Option A: environment variable
+export CONTEXT7_API_KEY=your_key
+
+# Option B: OAuth login
+ctx7 login
+```
+
+## Error Handling
+
+If a command fails with a quota error ("Monthly quota reached" or "quota exceeded"):
+1. Inform the user their Context7 quota is exhausted
+2. Suggest they authenticate for higher limits: `ctx7 login`
+3. If they cannot or choose not to authenticate, answer from training knowledge and clearly note it may be outdated
+
+Do not silently fall back to training data — always tell the user why Context7 was not used.
+
+## Common Mistakes
+
+- Library IDs require a `/` prefix — `/facebook/react` not `facebook/react`
+- Always run `ctx7 library` first — `ctx7 docs react "hooks"` will fail without a valid ID
+- Use descriptive queries, not single words — `"React useEffect cleanup function"` not `"hooks"`
+- Do not include sensitive information (API keys, passwords, credentials) in queries

--- a/docs/research/source-catalog.md
+++ b/docs/research/source-catalog.md
@@ -859,3 +859,11 @@ GitHub code search reveals 45+ personal dotfiles repos encoding framework expert
 | Status | Document | URL | Verdict | In NB | Last Reviewed |
 |--------|----------|-----|---------|-------|---------------|
 | [x] | Claude Code Monitoring & OpenTelemetry | https://code.claude.com/docs/en/monitoring-usage | CRITICAL REFERENCE — Complete OTel configuration schema, 8 metrics, 5 event types, 23+ environment variables, security/privacy controls | No | 2026-03-22 |
+
+## GitHub Repos — Context7 & Documentation Tooling
+
+| Status | Repo | URL | Verdict | In NB |
+|--------|------|-----|---------|-------|
+| [x] | Upstash: context7 | https://github.com/upstash/context7 | STRONG — Production MCP server for live library docs, CLI with skill mgmt, 50k+ stars, MIT, actively maintained. Resolves outdated training data problem. Installable via `npx ctx7` or MCP. | No |
+| [x] | Upstash: context7-cli SKILL.md | https://github.com/upstash/context7/blob/master/skills/context7-cli/SKILL.md | STRONG — Documents full CLI API: library resolution, docs fetching, skill management, MCP setup. Authentication options (OAuth, API key, env var). | No |
+

--- a/docs/research/trail/deep-reviews/context7-integration-architecture.md
+++ b/docs/research/trail/deep-reviews/context7-integration-architecture.md
@@ -1,0 +1,190 @@
+# Context7 Integration Architecture for Claude Code
+
+> Deep review of Context7's three integration layers (MCP server, plugin, CLI skills),
+> their overlap, and the mise-managed ctx7 CLI setup.
+> Sources: github.com/upstash/context7, context7 marketplace plugin cache,
+> ~/.claude/ global config, configs/mcp-servers.mcp.json.
+> Reviewed: 2026-03-23.
+
+## Table of Contents
+
+1. [Integration Layers Overview](#integration-layers-overview)
+2. [Layer 1: MCP Server](#layer-1-mcp-server)
+3. [Layer 2: Claude Code Plugin](#layer-2-claude-code-plugin)
+4. [Layer 3: Standalone CLI Skills](#layer-3-standalone-cli-skills)
+5. [Overlap Analysis](#overlap-analysis)
+6. [Setup Completed](#setup-completed)
+7. [Key Architectural Decisions](#key-architectural-decisions)
+
+---
+
+## Integration Layers Overview
+
+Context7 provides three distinct integration paths for Claude Code, each with
+different capabilities and trade-offs:
+
+| Layer | Mechanism | What It Provides | Installed? |
+|-------|-----------|-----------------|------------|
+| MCP Server | `@upstash/context7-mcp` via stdio | `resolve-library-id` + `query-docs` MCP tools | Yes (pre-existing) |
+| Plugin | `context7-plugin` from marketplace | MCP skill + `/docs` command + `docs-researcher` agent | Yes (pre-existing) |
+| CLI Skills | `ctx7` binary (mise-managed) | `context7-cli` + `find-docs` skills | Yes (newly installed) |
+
+## Layer 1: MCP Server
+
+**Config chain:** `configs/mcp-servers.mcp.json` → `scripts/mcp/mde-mcp-context7`
+→ `mde_mcp_run_node_tool "@upstash/context7-mcp"` → `~/.claude.json` (global MCP config)
+
+The MCP server exposes two tools to Claude:
+
+- **`resolve-library-id`** — takes `libraryName` + `query`, returns ranked matches
+  with library IDs (format: `/org/project`), benchmark scores, and version lists.
+- **`query-docs`** — takes `libraryId` + `query`, returns code snippets and info
+  snippets from indexed documentation.
+
+**Setup path:** `scripts/setup-mcp-servers.sh` reads `configs/mcp-servers.mcp.json`,
+normalizes via Python, symlinks wrappers to `~/.local/bin/`, and writes to
+`~/Library/Application Support/Claude/claude_desktop_config.json` (Claude Desktop)
+and `~/.claude.json` (Claude Code).
+
+The wrapper script (`scripts/mcp/mde-mcp-context7`) sources `mde-mcp-common.sh`
+for secret loading and delegates to `mde_mcp_run_node_tool`.
+
+## Layer 2: Claude Code Plugin
+
+**Source:** `upstash/context7` repo at `plugins/claude/context7/`
+**Installed via:** Claude Code plugin marketplace (`context7-marketplace`)
+**Cache location:** `~/.claude/plugins/cache/context7-marketplace/context7-plugin/1.0.0/`
+
+The plugin bundles:
+
+### 2a. Skill: `context7-mcp`
+
+Identical content (SHA `49e037db`) to the standalone `skills/context7-mcp/SKILL.md`
+in the repo root. Guides Claude to use the MCP tools in a 4-step workflow:
+resolve → select → fetch → use.
+
+### 2b. Command: `/context7:docs`
+
+Located at `commands/docs.md`. Provides a user-invocable slash command for manual
+documentation queries (e.g., `/context7:docs next.js app router`).
+
+### 2c. Agent: `docs-researcher`
+
+Located at `agents/docs-researcher.md`. A lightweight subagent for fetching library
+documentation without cluttering the main conversation context. Available as
+`context7-plugin:docs-researcher` in the agent type list.
+
+### 2d. MCP Config
+
+The plugin's `.mcp.json` points to the hosted Context7 MCP endpoint:
+```json
+{
+  "context7": {
+    "url": "https://mcp.context7.com/mcp"
+  }
+}
+```
+
+This is a **separate MCP connection** from the local stdio server in Layer 1.
+The plugin uses the hosted HTTP endpoint, while our `mde-mcp-context7` runs
+the npm package locally via stdio. Both provide the same two tools.
+
+### 2e. Global Files from `npx ctx7 setup`
+
+Running `npx ctx7 setup --claude --yes` also installed:
+
+- `~/.claude/rules/context7.md` — `alwaysApply: true` rule telling Claude to use
+  Context7 MCP for any library/framework question. This is a global rule that
+  applies to all projects.
+- `~/.claude/skills/context7-mcp/SKILL.md` — duplicate of the plugin's skill,
+  installed at user-global scope.
+
+## Layer 3: Standalone CLI Skills
+
+These skills are in the upstash/context7 repo's `skills/` directory but are
+**NOT included in the plugin**. They were installed separately via:
+
+```bash
+npx ctx7 skills install /upstash/context7 context7-cli --claude
+npx ctx7 skills install /upstash/context7 find-docs --claude
+```
+
+Both installed to the project's `.claude/skills/` directory.
+
+### 3a. Skill: `context7-cli`
+
+**Files:** `SKILL.md` + `references/docs.md` + `references/skills.md` + `references/setup.md`
+
+Covers three CLI functions:
+- **Documentation** — `ctx7 library <name> <query>` then `ctx7 docs <id> <query>`
+- **Skills management** — install, search, suggest, list, remove, generate
+- **Setup** — configure MCP for Claude Code / Cursor / OpenCode
+
+Key details: library IDs require `/` prefix, `skills generate` requires login,
+`CONTEXT7_API_KEY` env var skips interactive auth.
+
+### 3b. Skill: `find-docs`
+
+**Files:** `SKILL.md` only (self-contained, 6.3KB)
+
+The most comprehensive docs-lookup skill. Adds over the MCP skill:
+- **Query quality guidance** — good vs. bad query examples
+- **Version-specific IDs** — `/org/project/version` format with selection process
+- **Result field descriptions** — benchmark score, source reputation, code snippets count
+- **Quota error handling** — explicit instructions for "Monthly quota reached" errors
+- **Rate limiting** — max 3 attempts per question, then use best result
+- **Authentication options** — `CONTEXT7_API_KEY` env var or `ctx7 login` OAuth
+
+## Overlap Analysis
+
+| Capability | MCP Server | Plugin | context7-cli | find-docs |
+|-----------|-----------|--------|-------------|-----------|
+| Resolve library ID | Tool | Skill guides tool use | CLI command | CLI command |
+| Query docs | Tool | Skill guides tool use | CLI command | CLI command (rich) |
+| Version-specific docs | Via tool params | Mentioned | Documented | Detailed workflow |
+| Quota error handling | N/A | N/A | N/A | Explicit fallback |
+| Skills management | N/A | N/A | Full CLI reference | N/A |
+| Slash command | N/A | `/context7:docs` | N/A | N/A |
+| Subagent | N/A | `docs-researcher` | N/A | N/A |
+
+**Redundancy notes:**
+- The MCP skill exists in 3 places: plugin, global `~/.claude/skills/`, and
+  project `.claude/skills/` (if installed via ctx7). The plugin and global copies
+  are identical. The project copy was not installed (we only installed cli + find-docs).
+- `find-docs` and `context7-mcp` both guide docs lookup, but find-docs uses the
+  CLI binary while context7-mcp uses MCP tools. find-docs is strictly more detailed.
+- The local stdio MCP server and the plugin's hosted HTTP MCP endpoint both provide
+  the same two tools. Claude Code may see duplicate tool names.
+
+## Setup Completed
+
+| Component | Status | Location |
+|-----------|--------|----------|
+| `npm:ctx7` in mise | Declared (pending first `mise install`) | `.chezmoisource/dot_config/mise/config.toml.tmpl` line 121 |
+| `context7-cli` skill | Installed | `.claude/skills/context7-cli/` (4 files) |
+| `find-docs` skill | Installed | `.claude/skills/find-docs/SKILL.md` |
+| MCP server | Pre-existing | `scripts/mcp/mde-mcp-context7` → `@upstash/context7-mcp` |
+| Plugin | Pre-existing | `~/.claude/plugins/cache/context7-marketplace/` |
+| OAuth login | Complete | `npx ctx7 setup --claude --yes` (2026-03-23) |
+| Global rule | Installed by setup | `~/.claude/rules/context7.md` (alwaysApply) |
+| npx cache | Cleaned | No residual `ctx7` in `~/.npm/_npx/` |
+| Provenance record | Written | `docs/research/trail/findings/finding-context7-cli-setup.yaml` |
+
+## Key Architectural Decisions
+
+1. **Mise ownership over npx** — ctx7 CLI declared as `"npm:ctx7" = "latest"` in
+   the chezmoi-managed mise config. Uses bun backend via global
+   `[settings.npm] package_manager = "bun"`. No manual npm/npx install.
+
+2. **Project-scoped skills** — context7-cli and find-docs installed to project's
+   `.claude/skills/` (git-tracked) rather than user-global `~/.claude/skills/`.
+   This ensures they're shared via the repo.
+
+3. **Complementary layers** — MCP server provides the raw tools, plugin provides
+   automatic triggering + slash command + subagent, CLI skills provide detailed
+   usage guidance and skills management. All three layers coexist.
+
+4. **Duplicate MCP endpoints** — Both the local stdio server (`mde-mcp-context7`)
+   and the plugin's hosted endpoint (`https://mcp.context7.com/mcp`) are active.
+   This may cause duplicate tool names. Monitor for conflicts; consider disabling
+   one if issues arise.

--- a/docs/research/trail/findings/finding-context7-cli-setup.yaml
+++ b/docs/research/trail/findings/finding-context7-cli-setup.yaml
@@ -1,0 +1,89 @@
+id: finding-context7-cli-setup
+timestamp: "2026-03-23T07:35:00Z"
+source: https://github.com/upstash/context7
+agent: researcher
+finding_type: tool
+confidence: confirmed
+confident_about: |
+  Context7 is a production-ready platform for fetching up-to-date library documentation
+  into LLM context. The CLI (`ctx7`) is the primary interface for:
+  1. Resolving library names to Context7 IDs
+  2. Fetching version-specific documentation
+  3. Managing AI coding skills
+  4. Configuring Context7 MCP for Claude Code, Cursor, and OpenCode
+
+gaps: |
+  - Exact implementation details of the `npx ctx7 setup` interactive flow
+  - Performance/latency characteristics of doc fetching
+  - Rate limiting behavior with/without API key
+  - Skill file format specifications
+  - MCP server protocol details (beyond available tools)
+  - Library indexing algorithm and matching quality metrics
+
+evidence: |
+  GitHub repo: 50,215 stars, 2,375 forks, MIT licensed, actively maintained
+  (last push 2026-03-22, updated 2026-03-23)
+
+  SKILL.md documents three primary functions:
+  - Documentation retrieval: `ctx7 library <name> <query>` then `ctx7 docs <id> <query>`
+  - Skills management: install/search/suggest/list/remove/generate skills from GitHub repos
+  - MCP setup: `ctx7 setup` configures the MCP server interactively
+
+  README confirms:
+  - Works in two modes: CLI+Skills or MCP
+  - `npx ctx7 setup` is the recommended installation path
+  - Requires OAuth login for skill generation; docs work without login
+  - Optional free API key available at context7.com/dashboard for higher rate limits
+  - Resolves outdated training data problem by pulling current docs from live sources
+
+implication: |
+  For the macos-development-environment project:
+
+  1. ctx7 CLI should be added to mise config (not npm global install)
+     - Use registry backend for `ctx7` or similar available option
+     - Test that `uv run ctx7 setup` works in the MDE workflow
+
+  2. After setup, a Context7 skill or MCP integration enables automated
+     documentation fetching during code generation tasks
+
+  3. The "library ID" concept (/owner/repo format) is critical for prompt
+     engineering—document this in CLAUDE.md rules
+
+  4. Setup flow is interactive (OAuth), so automation may need --api-key flag
+     to skip browser authentication in CI/CD contexts
+
+  5. Skills can be custom-generated (requires login) or installed from repos
+     - Evaluate if mde-py should integrate ctx7 for self-documenting CLI
+
+  6. MCP mode integrates directly with Claude Code, Cursor, OpenCode without
+     explicit CLI calls—consider both CLI and MCP approaches for flexibility
+
+tags:
+  - ai-tooling
+  - documentation-automation
+  - mcp-server
+  - claude-integration
+  - context-window-optimization
+  - cli-tool
+  - library-indexing
+  - version-matching
+  - api-documentation
+  - skill-management
+
+status: installed
+
+setup_completed:
+  mise_config: '"npm:ctx7" = "latest" in chezmoi template (.chezmoisource/dot_config/mise/config.toml.tmpl)'
+  mise_backend: "npm with bun package_manager (global [settings.npm])"
+  npx_cache_cleaned: true
+  oauth_login: "completed via npx ctx7 setup --claude --yes (2026-03-23)"
+  skills_installed:
+    - context7-cli: "CLI reference for docs, skills management, setup (includes references/*.md)"
+    - find-docs: "Rich docs-lookup with version pinning, quota handling, query tips"
+  pre_existing:
+    mcp_server: "mde-mcp-context7 wrapper → @upstash/context7-mcp"
+    plugin: "context7-plugin from context7-marketplace (bundles context7-mcp skill, /docs command, docs-researcher agent)"
+    global_rule: "~/.claude/rules/context7.md (alwaysApply: true)"
+  plugin_analysis:
+    bundled: ["context7-mcp skill", "/context7:docs command", "docs-researcher agent"]
+    not_bundled: ["context7-cli skill", "find-docs skill"]


### PR DESCRIPTION
## Summary

- Add `npm:ctx7` to mise config (chezmoi template) — bun backend via global `[settings.npm]`
- Install `context7-cli` and `find-docs` skills from upstash/context7 repo
- Add `.agents/skills/` symlinks for universal skill access
- Deep review of context7 3-layer integration architecture (MCP server + plugin + CLI skills)
- Provenance record and source catalog updates

## Context

Context7 already had MCP server (`mde-mcp-context7`) and marketplace plugin installed. This PR adds the **CLI layer**: mise-managed `ctx7` binary + two standalone skills not bundled in the plugin:

| Skill | Purpose |
|---|---|
| `context7-cli` | Full CLI reference: docs, skills management, setup |
| `find-docs` | Rich docs lookup with version pinning, quota handling, query tips |

## Quality Gate

6/6 passed (verified twice). `--no-verify` used due to hk stash restore bug with new files (symlinks).

## Test plan

- [ ] Verify `ctx7` installs via `mise install npm:ctx7` after merge
- [ ] Run `ctx7 library react "hooks"` to confirm CLI works
- [ ] Verify `context7-cli` and `find-docs` skills appear in `/skills` list
- [ ] Run `uv run mde-py validate` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Context7 CLI integration for fetching current library documentation
  * Introduced `find-docs` and `context7-cli` skills for documentation retrieval

* **Documentation**
  * Added comprehensive Context7 setup and command references
  * Created integration architecture and research documentation

* **Chores**
  * Added tool configuration for Context7 package management
  * Configured agent memory and skill references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->