### PR TITLE
fix: debate diagnostics — OTLP health check, gemini empty-response detection

### DIFF
--- a/.claude/rules/observability-stack.md
+++ b/.claude/rules/observability-stack.md
@@ -24,11 +24,15 @@ GRAFANA_PASSWORD=$(fnox get GRAFANA_PASSWORD) docker compose -f docker/observabi
 ## Verifying health
 
 ```bash
-curl -sf http://localhost:13133  # OTEL Collector health
+curl -sf http://localhost:4318/v1/traces -X POST -d '{}' -H "Content-Type: application/json"  # OTLP HTTP endpoint
 curl -sf http://localhost:3100/ready  # Loki
 curl -sf http://localhost:3200/ready  # Tempo
 curl -sf http://localhost:3000/api/health  # Grafana
 ```
+
+Note: Port 13133 (OTEL Collector health check) is NOT exposed by the grafana/otel-lgtm
+all-in-one image. Use the OTLP HTTP endpoint (4318) with an empty POST to verify the
+collector is running.
 
 ## CLI telemetry configuration
 

--- a/src/mde/debate/invoke.py
+++ b/src/mde/debate/invoke.py
@@ -254,13 +254,18 @@ def _invoke_gemini(prompt: str, timeout: int = 300) -> InvocationResult:
 
         response = _extract_gemini_json(result.stdout)
 
+        # Mark as failed if returncode != 0 OR response is empty
+        # (empty response with rc=0 is a functional failure for debate)
+        is_success = result.returncode == 0 and bool(response)
         return InvocationResult(
             model="gemini",
             prompt=prompt,
             response=response,
-            success=result.returncode == 0,
+            success=is_success,
             duration_seconds=round(duration, 2),
-            error=result.stderr.strip()[:500] if result.returncode != 0 else None,
+            error=result.stderr.strip()[:500]
+            if result.returncode != 0
+            else ("Empty response from gemini" if not response else None),
         )
     except subprocess.TimeoutExpired:
         return InvocationResult(

--- a/src/mde/hooks/check_observability.py
+++ b/src/mde/hooks/check_observability.py
@@ -25,10 +25,12 @@ _TIMEOUT_SECONDS = 2
 
 # All services in the mde-observability LGTM stack with their health endpoints.
 # Uses grafana/otel-lgtm all-in-one image — all services share one container.
-_SERVICES: list[tuple[str, str]] = [
-    ("grafana", "http://localhost:3000/api/health"),
-    ("loki", "http://localhost:3100/ready"),
-    ("tempo", "http://localhost:3200/ready"),
+# Tuple: (name, url, requires_post). The OTLP endpoint needs POST with empty JSON.
+_SERVICES: list[tuple[str, str, bool]] = [
+    ("otlp-http", "http://localhost:4318/v1/traces", True),
+    ("grafana", "http://localhost:3000/api/health", False),
+    ("loki", "http://localhost:3100/ready", False),
+    ("tempo", "http://localhost:3200/ready", False),
 ]
 
 _STARTUP_CMD = (
@@ -37,10 +39,19 @@ _STARTUP_CMD = (
 )
 
 
-def _check_endpoint(url: str) -> bool:
+def _check_endpoint(url: str, *, post: bool = False) -> bool:
     """Return True if the health endpoint responds with HTTP 200."""
     try:
-        req = urllib.request.Request(url, method="GET")  # noqa: S310
+        if post:
+            data = b"{}"
+            req = urllib.request.Request(  # noqa: S310
+                url,
+                data=data,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+        else:
+            req = urllib.request.Request(url, method="GET")  # noqa: S310
         with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:  # noqa: S310
             return resp.status == _HTTP_OK  # type: ignore[no-any-return]
     except Exception:  # noqa: BLE001
@@ -49,7 +60,7 @@ def _check_endpoint(url: str) -> bool:
 
 def check_services() -> dict[str, bool]:
     """Check all observability services and return a name→healthy mapping."""
-    return {name: _check_endpoint(url) for name, url in _SERVICES}
+    return {name: _check_endpoint(url, post=post) for name, url, post in _SERVICES}
 
 
 def check_observability() -> int:

--- a/tests/test_hook_check_observability.py
+++ b/tests/test_hook_check_observability.py
@@ -35,6 +35,19 @@ class TestCheckEndpoint:
         _ = mock_urlopen
         assert _check_endpoint("http://localhost:13133") is False
 
+    @patch("mde.hooks.check_observability.urllib.request.urlopen")
+    def test_post_endpoint(self, mock_urlopen: MagicMock) -> None:
+        """POST endpoints send JSON body instead of GET."""
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        assert _check_endpoint("http://localhost:4318/v1/traces", post=True) is True
+        req = mock_urlopen.call_args[0][0]
+        assert req.method == "POST"
+        assert req.data == b"{}"
+
 
 class TestCheckServices:
     """Test multi-service health check."""
@@ -43,14 +56,16 @@ class TestCheckServices:
     def test_all_healthy(self, mock_check: MagicMock) -> None:
         results = check_services()
         assert all(results.values())
-        assert set(results.keys()) == {"grafana", "loki", "tempo"}
-        assert mock_check.call_count == 3
+        assert set(results.keys()) == {"otlp-http", "grafana", "loki", "tempo"}
+        assert mock_check.call_count == 4
 
     @patch("mde.hooks.check_observability._check_endpoint")
     def test_partial_failure(self, mock_check: MagicMock) -> None:
         """Reports which specific services are down."""
-        mock_check.side_effect = [True, False, True]  # grafana ok, loki down, tempo ok
+        # otlp ok, grafana ok, loki down, tempo ok
+        mock_check.side_effect = [True, True, False, True]
         results = check_services()
+        assert results["otlp-http"] is True
         assert results["grafana"] is True
         assert results["loki"] is False
         assert results["tempo"] is True
@@ -59,4 +74,16 @@ class TestCheckServices:
     def test_all_down(self, mock_check: MagicMock) -> None:
         results = check_services()
         assert not any(results.values())
-        assert mock_check.call_count == 3
+        assert mock_check.call_count == 4
+
+    @patch("mde.hooks.check_observability._check_endpoint")
+    def test_otlp_uses_post(self, mock_check: MagicMock) -> None:
+        """OTLP endpoint is checked with POST, others with GET."""
+        mock_check.return_value = True
+        check_services()
+        calls = mock_check.call_args_list
+        # First call is otlp-http with post=True
+        assert calls[0].kwargs.get("post") is True
+        # Rest use post=False
+        for call in calls[1:]:
+            assert call.kwargs.get("post") is False


### PR DESCRIPTION
## Summary
- Diagnosed Codex/Gemini CLI failures: both work correctly, prior 300s timeout was cold-start (92K tokens context load + OTEL startup)
- Added OTLP HTTP endpoint (POST :4318) to `check_observability` hook since `grafana/otel-lgtm` doesn't expose port 13133
- Gemini backend now detects empty responses as failures (parity with Codex)
- Updated observability-stack rule with correct health check commands
- Validated: JSONL parsing, retry logic, telemetry landing in Tempo/Loki all confirmed working

## Test Plan
- [x] Quality gate 6/6 (639 tests, 0 errors)
- [x] `mde debate "..." --model codex` succeeds with correct JSONL parsing
- [x] `mde debate "..." --model gemini` succeeds with correct JSON extraction
- [x] Traces visible in Tempo, structured logs in Loki
- [x] New tests for POST endpoint check and OTLP probe verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated observability health check documentation to verify OTEL Collector using the OTLP HTTP endpoint instead of unavailable methods.

* **Bug Fixes**
  * Improved Gemini invocation validation to detect and report empty responses as errors.
  * Extended service health checks to support POST-based endpoints.

* **Tests**
  * Added test coverage for POST-based health check endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->