### PR TITLE
feat: add guard-main-commit hook to prevent direct-to-main commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,10 @@
           },
           {
             "type": "command",
+            "command": "uv run mde-py hooks guard-main-commit"
+          },
+          {
+            "type": "command",
             "command": "$HOME/.claude/hooks/rtk-rewrite.sh"
           }
         ]

--- a/src/mde/hooks/guard_main_commit.py
+++ b/src/mde/hooks/guard_main_commit.py
@@ -1,0 +1,113 @@
+"""PreToolUse hook: warn when git commit is run on the main branch.
+
+Detects git commit commands in Bash tool calls and emits an advisory warning
+if the current branch is main/master. This prevents accidental direct-to-main
+commits that bypass the worktree PR workflow.
+"""
+
+from __future__ import annotations
+
+# AUTO-DISCOVERED: This hook is registered automatically by cli.py via __hook_meta__.
+# To add a new hook, create a new module in src/mde/hooks/ with __hook_meta__ — do NOT edit cli.py.
+__hook_meta__ = {
+    "help": "PreToolUse guard against committing on main (advisory)",
+    "entry": "guard_main_commit",
+}
+
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Any
+
+from mde.hooks._common import hook_span, parse_hook_stdin
+from mde.log import logger
+
+_COMMIT_PATTERN = re.compile(r"\bgit\s+commit\b")
+
+_SAFE_BRANCHES = {"main", "master"}
+
+_WARN_MESSAGE = (
+    "WARNING: You are about to commit directly to the main branch. "
+    "Use the worktree PR workflow instead: "
+    "git worktree add .claude/worktrees/<name> -b feat/<name>. "
+    "See worktree-pr-workflow.md for the policy."
+)
+
+
+def _current_branch() -> str | None:
+    """Return the current git branch name, or None if detached/unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={"GIT_TERMINAL_PROMPT": "0", "PATH": os.environ.get("PATH", "")},
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError):
+        pass  # git unavailable — treat as non-main branch
+    return None
+
+
+def check_main_commit(command: str) -> dict[str, Any] | None:
+    """Return an advisory allow dict with systemMessage if committing on main, else None."""
+    if not command:
+        return None
+
+    if not _COMMIT_PATTERN.search(command):
+        return None
+
+    branch = _current_branch()
+    if branch not in _SAFE_BRANCHES:
+        return None
+
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+        },
+        "systemMessage": _WARN_MESSAGE,
+    }
+
+
+def guard_main_commit() -> int:
+    """Entry point: read JSON from stdin, warn if committing on main."""
+    try:
+        data = parse_hook_stdin()
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.bind(hook="guard_main_commit", error=str(exc)).warning("hook_stdin_parse_failed")
+        return 0
+
+    with hook_span("guard_main_commit", "PreToolUse", data) as span:
+        tool_input = data.get("tool_input") or {}
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+        command = tool_input.get("command", "")
+        if not command:
+            span.set_attribute("hook.warned", False)  # noqa: FBT003
+            logger.bind(hook="guard_main_commit", warned="False", reason="no_command").info(
+                "hook_completed"
+            )
+            return 0
+
+        result = check_main_commit(command)
+        warned = result is not None
+        span.set_attribute("hook.warned", warned)
+        if result is not None:
+            json.dump(result, sys.stdout)
+
+        session_id = data.get("session_id", "")
+        logger.bind(
+            hook="guard_main_commit",
+            warned=str(warned),
+            command=command,
+            session_id=session_id,
+        ).info("hook_completed")
+        return 0
+
+
+__all__ = ["check_main_commit", "guard_main_commit"]

--- a/tests/test_hook_guard_main_commit.py
+++ b/tests/test_hook_guard_main_commit.py
@@ -1,0 +1,61 @@
+"""Tests for the guard_main_commit PreToolUse hook."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from mde.hooks.guard_main_commit import check_main_commit
+
+
+class TestCheckMainCommit:
+    """Unit tests for check_main_commit logic."""
+
+    def test_empty_command_returns_none(self) -> None:
+        assert check_main_commit("") is None
+
+    def test_non_commit_command_returns_none(self) -> None:
+        assert check_main_commit("git status") is None
+        assert check_main_commit("git push origin main") is None
+        assert check_main_commit("git log --oneline") is None
+
+    @patch("mde.hooks.guard_main_commit._current_branch", return_value="main")
+    def test_commit_on_main_warns(self, mock_branch: object) -> None:
+        result = check_main_commit("git commit -m 'test'")
+        assert result is not None
+        assert result["hookSpecificOutput"]["permissionDecision"] == "allow"
+        assert "WARNING" in result["systemMessage"]
+        assert "worktree" in result["systemMessage"].lower()
+
+    @patch("mde.hooks.guard_main_commit._current_branch", return_value="master")
+    def test_commit_on_master_warns(self, mock_branch: object) -> None:
+        result = check_main_commit("git commit -m 'test'")
+        assert result is not None
+        assert result["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+    @patch("mde.hooks.guard_main_commit._current_branch", return_value="feat/my-feature")
+    def test_commit_on_feature_branch_returns_none(self, mock_branch: object) -> None:
+        assert check_main_commit("git commit -m 'test'") is None
+
+    @patch("mde.hooks.guard_main_commit._current_branch", return_value="main")
+    def test_commit_amend_on_main_warns(self, mock_branch: object) -> None:
+        result = check_main_commit("git commit --amend")
+        assert result is not None
+
+    @patch("mde.hooks.guard_main_commit._current_branch", return_value="main")
+    def test_chained_command_with_commit_warns(self, mock_branch: object) -> None:
+        result = check_main_commit("git add -A && git commit -m 'test'")
+        assert result is not None
+
+    @patch("mde.hooks.guard_main_commit._current_branch", return_value=None)
+    def test_detached_head_returns_none(self, mock_branch: object) -> None:
+        """Detached HEAD (None) should not warn."""
+        assert check_main_commit("git commit -m 'test'") is None
+
+    def test_git_committed_not_matched(self) -> None:
+        """Past tense 'committed' should not trigger."""
+        assert check_main_commit("echo 'changes committed'") is None
+
+    @patch("mde.hooks.guard_main_commit._current_branch", return_value="main")
+    def test_heredoc_commit_on_main_warns(self, mock_branch: object) -> None:
+        result = check_main_commit("git commit -m \"$(cat <<'EOF'\nfeat: my change\nEOF\n)\"")
+        assert result is not None


### PR DESCRIPTION
## Summary
- Adds `guard-main-commit` PreToolUse advisory hook that warns when `git commit` is detected on main/master branch
- Directs users to the worktree PR workflow instead of direct-to-main commits
- Follows hooks-auto-discovery convention (`__hook_meta__`), includes OTEL tracing via `hook_span`
- Wired in `.claude/settings.json` under the Bash PreToolUse matcher

## Motivation
Process violation in commits 017e596 and 885f1c5 (direct-to-main) motivated this guard. The hook is advisory (exit 0, `permissionDecision: allow` with `systemMessage` warning) — it doesn't block, just warns.

## Test plan
- [x] 10 unit tests covering: main/master detection, feature branch pass-through, chained commands, detached HEAD, amend, heredoc patterns
- [x] ruff check: 0 errors
- [x] ruff format: 204 files formatted
- [x] ty check: 0 new diagnostics
- [x] pyright: 0 errors
- [x] pytest: 646 passed (1 skip: worktree-inherent mise doctor trust issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a safeguard that detects and alerts developers when attempting to commit directly to main or master branches, recommending the use of the worktree PR workflow as an alternative.

* **Tests**
  * Added comprehensive unit tests to validate the new commit branch protection feature across multiple git commands, branch scenarios, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->